### PR TITLE
Configurable http headers for rest specs

### DIFF
--- a/src/main/java/com/adven/concordion/extensions/exam/rest/StatusBuilder.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/rest/StatusBuilder.java
@@ -1,0 +1,33 @@
+package com.adven.concordion.extensions.exam.rest;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Ruslan Ustits
+ */
+public final class StatusBuilder {
+
+    private static final String DEFAULT_PROTOCOL = "HTTP/1.1";
+    private static final String DEFAULT_STATUS_CODE = "200";
+    private static final String DEFAULT_REASON_PHRASE = "OK";
+
+    private final String protocol;
+    private final String status;
+    private final String reason;
+
+    public StatusBuilder(final String protocol, final String status, final String reason) {
+        this.protocol = protocol == null ? DEFAULT_PROTOCOL : protocol;
+        this.status = status == null ? DEFAULT_STATUS_CODE : status;
+        this.reason = reason == null ? DEFAULT_REASON_PHRASE : reason;
+    }
+
+    public String build() {
+        final String raw = StringUtils.join(new String[]{protocol, status, reason}, ' ');
+        return clean(raw);
+    }
+
+    protected String clean(final String status) {
+        return status.replaceAll("\\b\\s*$", "");
+    }
+
+}

--- a/src/main/java/com/adven/concordion/extensions/exam/rest/commands/CaseCommand.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/rest/commands/CaseCommand.java
@@ -66,14 +66,19 @@ public class CaseCommand extends RestVerifyCommand {
         Html body = caseRoot.first(BODY);
         Html expected = caseRoot.first(EXPECTED);
         caseRoot.remove(body, expected);
-        for (Map<String, Object> ignored : cases) {
-            caseRoot.childs(
-                    Html.tag(CASE).childs(
-                            body == null ? null : Html.tag(BODY).text(body.text()),
-                            Html.tag(EXPECTED).text(expected.text())
-                    )
-            );
+        caseRoot.childs(
+                caseTags(body, expected));
+    }
+
+    private Html[] caseTags(final Html body, final Html expected) {
+        final List<Html> caseTags = new ArrayList<>();
+        for (int i = 0; i < cases.size(); i++) {
+            final Html bodyToAdd = body == null ? null : Html.tag(BODY).text(body.text());
+            final Html expectedToAdd = Html.tag(EXPECTED).text(expected.text());
+            final Html caseTag = Html.tag(CASE).childs(bodyToAdd, expectedToAdd);
+            caseTags.add(caseTag);
         }
+        return caseTags.toArray(new Html[]{});
     }
 
     @Override

--- a/src/test/java/com/adven/concordion/extensions/exam/rest/StatusBuilderTest.java
+++ b/src/test/java/com/adven/concordion/extensions/exam/rest/StatusBuilderTest.java
@@ -1,0 +1,34 @@
+package com.adven.concordion.extensions.exam.rest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Ruslan Ustits
+ */
+public class StatusBuilderTest {
+
+    private StatusBuilder builder;
+
+    @Before
+    public void setUp() {
+        final String protocol = "protocol";
+        final String status = "status";
+        final String reason = "reason";
+        builder = new StatusBuilder(protocol, status, reason);
+    }
+
+    @Test
+    public void testBuild() {
+        final String result = builder.build();
+        assertEquals("protocol status reason", result);
+    }
+
+    @Test
+    public void testClean() {
+        assertEquals("some text with spaces", builder.clean("some text with spaces  "));
+    }
+
+}

--- a/src/test/resources/specs/rs/get/Get.md
+++ b/src/test/resources/specs/rs/get/Get.md
@@ -32,6 +32,15 @@
             </e:case>
         </e:get>
     </e:example>
+    <e:example name="Check failed status code" print="true">
+        <e:get url="status/400">
+            <e:case desc="Wrong status code was expected">
+                <expected statusCode="400" reasonPhrase="Bad Request">
+                    {"get": "/status/400"}
+                </expected>
+            </e:case>
+        </e:get>
+    </e:example>
     <e:example name="Cookies" print="true">
         <e:get url="relative/url" cookies="cook=from_command">
             <e:case desc="Can be set in command">


### PR DESCRIPTION
added an ability to configure expected protocol/statusCode/reasonPhrase e.g.:
``` xml
<e:example name="Check failed status code" print="true">
    <e:get url="status/400">
        <e:case desc="Wrong status code was expected">
            <expected statusCode="400" reasonPhrase="Bad Request">
                {"get": "/status/400"}
            </expected>
        </e:case>
    </e:get>
</e:example>
```