### PR TITLE
kafka headers support

### DIFF
--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/DefaultEventProcessor.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/DefaultEventProcessor.java
@@ -47,15 +47,16 @@ public final class DefaultEventProcessor implements EventProcessor {
             log.warn("Can't send null event");
             return false;
         }
-        return send(event.getTopicName(), event.getKey(), event.getMessage());
+        return send(event.getTopicName(), event.getKey(), event.getMessage(), event.getHeader());
     }
 
-    protected boolean send(final String topic, final String key, final ProtoEntity message) {
+    protected boolean send(final String topic, final String key, final ProtoEntity message,
+                           final EventHeader header) {
         if (StringUtils.isBlank(topic) || message == null) {
             log.warn("Unable to send record with topic={}, key={}, message={}. Missing required parameters",
                 topic, key, message);
             return false;
         }
-        return eventProducer.produce(topic, key, message);
+        return eventProducer.produce(topic, key, header, message);
     }
 }

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
@@ -15,6 +15,7 @@ public final class EventBlockParser implements HtmlBlockParser<Event<ProtoEntity
     public Optional<Event<ProtoEntity>> parse(final Html html) {
         final String topicName = html.attr(TOPIC_NAME);
         final String key = html.attr(EVENT_KEY);
+        val headers = new HeaderBlockParser().parse(html);
         val proto = new ProtoBlockParser().parse(html);
         if (proto.isPresent()) {
             val message = proto.get();
@@ -22,6 +23,7 @@ public final class EventBlockParser implements HtmlBlockParser<Event<ProtoEntity
                 .topicName(topicName)
                 .key(key)
                 .message(message)
+                .header(headers.isPresent() ? headers.get() : null)
                 .build());
         }
         return Optional.absent();

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
@@ -1,0 +1,30 @@
+package com.adven.concordion.extensions.exam.kafka;
+
+import com.adven.concordion.extensions.exam.html.Html;
+import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoBlockParser;
+import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoEntity;
+import com.google.common.base.Optional;
+import lombok.val;
+
+public final class EventBlockParser implements HtmlBlockParser<Event<ProtoEntity>> {
+
+    private static final String TOPIC_NAME = "topicName";
+    private static final String EVENT_KEY = "key";
+
+    @Override
+    public Optional<Event<ProtoEntity>> parse(final Html html) {
+        final String topicName = html.attr(TOPIC_NAME);
+        final String key = html.attr(EVENT_KEY);
+        val proto = new ProtoBlockParser().parse(html);
+        if (proto.isPresent()) {
+            val message = proto.get();
+            return Optional.of(Event.<ProtoEntity>builder()
+                .topicName(topicName)
+                .key(key)
+                .message(message)
+                .build());
+        }
+        return Optional.absent();
+    }
+
+}

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
@@ -8,15 +8,20 @@ import lombok.val;
 
 public final class EventBlockParser implements HtmlBlockParser<Event<ProtoEntity>> {
 
-    private static final String TOPIC_NAME = "topicName";
-    private static final String EVENT_KEY = "key";
+    static final String TOPIC_NAME = "topicName";
+    static final String EVENT_KEY = "key";
+    static final String EVENT_VALUE = "value";
 
     @Override
     public Optional<Event<ProtoEntity>> parse(final Html html) {
         final String topicName = html.attr(TOPIC_NAME);
         final String key = html.attr(EVENT_KEY);
         val headers = new HeaderBlockParser().parse(html);
-        val proto = new ProtoBlockParser().parse(html);
+        val value = html.first(EVENT_VALUE);
+        if (value == null) {
+            return Optional.absent();
+        }
+        val proto = new ProtoBlockParser().parse(value);
         if (proto.isPresent()) {
             val message = proto.get();
             return Optional.of(Event.<ProtoEntity>builder()

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/EventBlockParser.java
@@ -4,20 +4,28 @@ import com.adven.concordion.extensions.exam.html.Html;
 import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoBlockParser;
 import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoEntity;
 import com.google.common.base.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 
+@RequiredArgsConstructor
 public final class EventBlockParser implements HtmlBlockParser<Event<ProtoEntity>> {
 
     static final String TOPIC_NAME = "topicName";
     static final String EVENT_KEY = "key";
-    static final String EVENT_VALUE = "value";
+    private static final String DEFAULT_EVENT_VALUE_BLOCK = "value";
+
+    private final String valueBlockName;
+
+    public EventBlockParser() {
+        this(DEFAULT_EVENT_VALUE_BLOCK);
+    }
 
     @Override
     public Optional<Event<ProtoEntity>> parse(final Html html) {
         final String topicName = html.attr(TOPIC_NAME);
         final String key = html.attr(EVENT_KEY);
         val headers = new HeaderBlockParser().parse(html);
-        val value = html.first(EVENT_VALUE);
+        val value = html.first(valueBlockName);
         if (value == null) {
             return Optional.absent();
         }

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/EventHeader.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/EventHeader.java
@@ -1,9 +1,11 @@
 package com.adven.concordion.extensions.exam.kafka;
 
 import lombok.NonNull;
+import lombok.ToString;
 
 import java.util.Arrays;
 
+@ToString
 public final class EventHeader {
 
     public static final String REPLY_TOPIC = "kafka_replyTopic";

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/HeaderBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/HeaderBlockParser.java
@@ -1,0 +1,40 @@
+package com.adven.concordion.extensions.exam.kafka;
+
+import com.adven.concordion.extensions.exam.html.Html;
+import com.google.common.base.Optional;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.io.UnsupportedEncodingException;
+
+@Slf4j
+public final class HeaderBlockParser implements HtmlBlockParser<EventHeader> {
+
+    static final String REPLY_TO_TOPIC = "replyToTopic";
+    static final String COR_ID = "correlationId";
+
+    @Override
+    public Optional<EventHeader> parse(final Html html) {
+        val headers = html.first("headers");
+        if (headers == null) {
+            return Optional.absent();
+        }
+        val replyToTopic = headers.first(REPLY_TO_TOPIC);
+        val correlationId = headers.first(COR_ID);
+        return Optional.of(buildHeader(replyToTopic, correlationId));
+    }
+
+    private EventHeader buildHeader(final Html replyToTopic, final Html correlationId) {
+        return new EventHeader(retrieveTextInBytes(replyToTopic), retrieveTextInBytes(correlationId));
+    }
+
+    protected byte[] retrieveTextInBytes(final Html html) {
+        try {
+            return html == null ? new byte[]{} : html.text().getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            log.error("Bad encoding", e);
+        }
+        return new byte[]{};
+    }
+
+}

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/HtmlBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/HtmlBlockParser.java
@@ -1,0 +1,10 @@
+package com.adven.concordion.extensions.exam.kafka;
+
+import com.adven.concordion.extensions.exam.html.Html;
+import com.google.common.base.Optional;
+
+public interface HtmlBlockParser<T> {
+
+    Optional<T> parse(final Html html);
+
+}

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/BaseEventCommand.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/BaseEventCommand.java
@@ -46,8 +46,8 @@ abstract class BaseEventCommand extends ExamCommand {
         return div().childs(
             h(4, text),
             h(5, "").childs(
-                badge(topicName, "primary"),
-                badge(protobufClass, "secondary"),
+                badge(topicName == null ? "" : topicName, "primary"),
+                badge(protobufClass == null ? "" : protobufClass, "secondary"),
                 code("protobuf")));
     }
 

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/BaseEventCommand.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/BaseEventCommand.java
@@ -2,15 +2,22 @@ package com.adven.concordion.extensions.exam.kafka.commands;
 
 import com.adven.concordion.extensions.exam.commands.ExamCommand;
 import com.adven.concordion.extensions.exam.html.Html;
+import com.adven.concordion.extensions.exam.html.HtmlBuilder;
+import com.adven.concordion.extensions.exam.kafka.Event;
 import com.adven.concordion.extensions.exam.kafka.EventProcessor;
 import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoEntity;
 import com.adven.concordion.extensions.exam.rest.JsonPrettyPrinter;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+
+import java.io.UnsupportedEncodingException;
+import java.util.*;
 
 import static com.adven.concordion.extensions.exam.html.HtmlBuilder.*;
 
+@Slf4j
 abstract class BaseEventCommand extends ExamCommand {
 
     protected static final String TOPIC_NAME = "topicName";
@@ -44,24 +51,60 @@ abstract class BaseEventCommand extends ExamCommand {
                 code("protobuf")));
     }
 
-    protected Html tableResult(final String message) {
-        return tableResult("", message);
-    }
-
-
-    protected Html tableResult(final String header, final String message) {
+    protected Html tableResult(final String message, final String... headers) {
         final Html table = eventTable();
         final JsonPrettyPrinter printer = new JsonPrettyPrinter();
+        val headerColumn = td();
+        for (val header : headers) {
+            headerColumn.childs(
+                HtmlBuilder.tag("dd").childs(
+                    code(header)));
+        }
         table.childs(
             tbody().childs(
-                td().childs(code(header)),
+                headerColumn,
                 td(printer.prettyPrint(message)).css("json")));
         return table;
     }
 
+    protected Html buildProtoInfo(final Event<ProtoEntity> event, final String infoHeader) {
+        final Map<String, String> headers = new HashMap<>();
+        if (event.getKey() != null) {
+            headers.put(EVENT_KEY, event.getKey());
+        }
+        if (event.getHeader() != null) {
+            val eventHeader = event.getHeader();
+            if (eventHeader.getReplyToTopic().length > 0) {
+                headers.put("replyTopic", bytesToString(eventHeader.getReplyToTopic()));
+            }
+            if (eventHeader.getCorrelationId().length > 0) {
+                headers.put("correlationId", bytesToString(eventHeader.getCorrelationId()));
+            }
+        }
+        return buildProtoInfo(event.getMessage(), infoHeader, event.getTopicName(), headers);
+    }
+
+    private String bytesToString(final byte[] bytes) {
+        try {
+            return new String(bytes, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            log.error("Wrong encoding", e);
+        }
+        return "";
+    }
+
     protected Html buildProtoInfo(final ProtoEntity proto, final String header, final String topicName) {
+        return buildProtoInfo(proto, header, topicName, Collections.<String, String>emptyMap());
+    }
+
+    private Html buildProtoInfo(final ProtoEntity proto, final String header, final String topicName,
+                                final Map<String, String> eventHeaders) {
         val info = eventInfo(header, topicName, proto.getClassName());
-        val table = tableResult(proto.getJsonValue());
+        final List<String> headers = new ArrayList<>();
+        for (val entry : eventHeaders.entrySet()) {
+            headers.add(entry.getKey() + "=" + entry.getValue());
+        }
+        val table = tableResult(proto.getJsonValue(), headers.toArray(new String[]{}));
         info.dropAllTo(table);
         return info;
     }

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/EventSendCommand.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/EventSendCommand.java
@@ -26,13 +26,12 @@ public final class EventSendCommand extends BaseEventCommand {
         final boolean result;
         if (parsedEvent.isPresent()) {
             val event = parsedEvent.get();
-            val info = buildProtoInfo(event.getMessage(), "Send message to", event.getTopicName());
+            val info = buildProtoInfo(event, "Send message to");
             root.childs(info);
             result = getEventProcessor().send(event);
         } else {
             result = false;
         }
-
         if (!result) {
             root.parent().attr("class", "").css("rest-failure bd-callout bd-callout-danger");
             root.text("Failed to send message to kafka");

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/EventSendCommand.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/commands/EventSendCommand.java
@@ -1,10 +1,8 @@
 package com.adven.concordion.extensions.exam.kafka.commands;
 
 import com.adven.concordion.extensions.exam.html.Html;
-import com.adven.concordion.extensions.exam.kafka.Event;
+import com.adven.concordion.extensions.exam.kafka.EventBlockParser;
 import com.adven.concordion.extensions.exam.kafka.EventProcessor;
-import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoBlockParser;
-import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoEntity;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.concordion.api.CommandCall;
@@ -22,21 +20,14 @@ public final class EventSendCommand extends BaseEventCommand {
     @Override
     public void setUp(final CommandCall commandCall, final Evaluator evaluator, final ResultRecorder resultRecorder) {
         val root = new Html(commandCall.getElement());
-        final String topicName = root.attr(TOPIC_NAME);
-        final String key = root.attr(EVENT_KEY);
-        val proto = new ProtoBlockParser().parse(root);
+        val parsedEvent = new EventBlockParser().parse(root);
         root.removeAllChild();
 
         final boolean result;
-        if (proto.isPresent()) {
-            val message = proto.get();
-            val info = buildProtoInfo(message, "Send message to", topicName);
+        if (parsedEvent.isPresent()) {
+            val event = parsedEvent.get();
+            val info = buildProtoInfo(event.getMessage(), "Send message to", event.getTopicName());
             root.childs(info);
-            val event = Event.<ProtoEntity>builder()
-                .topicName(topicName)
-                .key(key)
-                .message(message)
-                .build();
             result = getEventProcessor().send(event);
         } else {
             result = false;

--- a/src/main/java/com/adven/concordion/extensions/exam/kafka/protobuf/ProtoBlockParser.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/kafka/protobuf/ProtoBlockParser.java
@@ -1,6 +1,7 @@
 package com.adven.concordion.extensions.exam.kafka.protobuf;
 
 import com.adven.concordion.extensions.exam.html.Html;
+import com.adven.concordion.extensions.exam.kafka.HtmlBlockParser;
 import com.google.common.base.Optional;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -10,13 +11,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public final class ProtoBlockParser {
+public final class ProtoBlockParser implements HtmlBlockParser<ProtoEntity> {
 
     private static final String PROTOBUF = "protobuf";
     private static final String CLASS = "class";
     private static final String DESCRIPTOR = "descriptor";
     private static final String DESCRIPTORS = DESCRIPTOR + "s";
 
+    @Override
     public Optional<ProtoEntity> parse(final Html html) {
         val protoBlock = html.first(PROTOBUF);
         if (protoBlock == null) {

--- a/src/test/java/com/adven/concordion/extensions/exam/kafka/DefaultEventProcessorTest.java
+++ b/src/test/java/com/adven/concordion/extensions/exam/kafka/DefaultEventProcessorTest.java
@@ -27,32 +27,32 @@ public class DefaultEventProcessorTest {
     @Test
     public void testSuccessSend() {
         eventProducer.mustReturnTrue();
-        final boolean result = processor.send(anyString(), anyString(), mockEntity());
+        final boolean result = processor.send(anyString(), anyString(), mockEntity(), EventHeader.empty());
         assertThat(result).isTrue();
     }
 
     @Test
     public void testFailedSend() {
         eventProducer.mustReturnFalse();
-        final boolean result = processor.send(anyString(), anyString(), mockEntity());
+        final boolean result = processor.send(anyString(), anyString(), mockEntity(), EventHeader.empty());
         assertThat(result).isFalse();
     }
 
     @Test
     public void testSendWithNullTopic() {
-        final boolean result = processor.send(null, null, mockEntity());
+        final boolean result = processor.send(null, null, mockEntity(), EventHeader.empty());
         assertThat(result).isFalse();
     }
 
     @Test
     public void testSendWithEmptyTopic() {
-        final boolean result = processor.send("", null, mockEntity());
+        final boolean result = processor.send("", null, mockEntity(), EventHeader.empty());
         assertThat(result).isFalse();
     }
 
     @Test
     public void testSendWithNullMessage() {
-        final boolean result = processor.send(anyString(), null, null);
+        final boolean result = processor.send(anyString(), null, null, EventHeader.empty());
         assertThat(result).isFalse();
     }
 

--- a/src/test/java/com/adven/concordion/extensions/exam/kafka/EventBlockParserTest.java
+++ b/src/test/java/com/adven/concordion/extensions/exam/kafka/EventBlockParserTest.java
@@ -1,0 +1,30 @@
+package com.adven.concordion.extensions.exam.kafka;
+
+import com.adven.concordion.extensions.exam.html.Html;
+import com.adven.concordion.extensions.exam.kafka.protobuf.ProtoEntity;
+import com.google.common.base.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.adven.concordion.extensions.exam.RandomUtils.anyString;
+import static com.adven.concordion.extensions.exam.html.HtmlBuilder.div;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventBlockParserTest {
+
+    private EventBlockParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new EventBlockParser();
+    }
+
+    @Test
+    public void testParseWithNullValue() {
+        final Html html = div().attr(EventBlockParser.TOPIC_NAME, anyString())
+            .attr(EventBlockParser.EVENT_KEY, anyString());
+        final Optional<Event<ProtoEntity>> result = parser.parse(html);
+        assertThat(result).isEqualTo(Optional.absent());
+    }
+
+}

--- a/src/test/java/com/adven/concordion/extensions/exam/kafka/HeaderBlockParserTest.java
+++ b/src/test/java/com/adven/concordion/extensions/exam/kafka/HeaderBlockParserTest.java
@@ -1,0 +1,67 @@
+package com.adven.concordion.extensions.exam.kafka;
+
+import com.adven.concordion.extensions.exam.html.Html;
+import com.google.common.base.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static com.adven.concordion.extensions.exam.RandomUtils.anyString;
+import static com.adven.concordion.extensions.exam.html.HtmlBuilder.div;
+import static com.adven.concordion.extensions.exam.html.HtmlBuilder.tag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeaderBlockParserTest {
+
+    private HeaderBlockParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new HeaderBlockParser();
+    }
+
+    @Test
+    public void testParse() throws UnsupportedEncodingException {
+        final String replyToTopic = anyString();
+        final String correlationId = anyString();
+        final Html html = div().childs(
+            tag("headers").childs(
+                tag(HeaderBlockParser.REPLY_TO_TOPIC).text(replyToTopic),
+                tag(HeaderBlockParser.COR_ID).text(correlationId)
+            ));
+        final Optional<EventHeader> result = parser.parse(html);
+        assertThat(result).isEqualTo(
+            Optional.of(
+                new EventHeader(
+                    replyToTopic.getBytes("UTF-8"),
+                    correlationId.getBytes("UTF-8"))));
+    }
+
+    @Test
+    public void testParseWithNoHeadersTag() {
+        final Optional<EventHeader> result = parser.parse(div());
+        assertThat(result).isEqualTo(Optional.absent());
+    }
+
+    @Test
+    public void testParseWithNoHeadersSpecified() {
+        final Optional<EventHeader> result = parser.parse(div().childs(tag("headers")));
+        assertThat(result).isEqualTo(Optional.of(new EventHeader(new byte[]{}, new byte[]{})));
+    }
+
+    @Test
+    public void testRetrieveTextInBytes() throws UnsupportedEncodingException {
+        final String text = anyString();
+        final Html html = div().text(text);
+        final byte[] result = parser.retrieveTextInBytes(html);
+        assertThat(result).isEqualTo(text.getBytes("UTF-8"));
+    }
+
+    @Test
+    public void testRetrieveTextInBytesWithNullHtml() {
+        final byte[] result = parser.retrieveTextInBytes(null);
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/src/test/java/specs/kafka/send/Send.java
+++ b/src/test/java/specs/kafka/send/Send.java
@@ -13,7 +13,6 @@ public class Send extends Kafka {
         final ConsumerRecord<String, Bytes> record = consumeSingleEvent();
         final Entity entity = Entity.parseFrom(record.value().get());
         return entity.getName().equals("happy little name") && entity.getNumber() == 12;
-
     }
 
 }

--- a/src/test/java/specs/kafka/send/Send.java
+++ b/src/test/java/specs/kafka/send/Send.java
@@ -1,9 +1,13 @@
 package specs.kafka.send;
 
+import com.adven.concordion.extensions.exam.kafka.EventHeader;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 import specs.kafka.Kafka;
+
+import java.io.UnsupportedEncodingException;
 
 import static com.adven.concordion.extensions.exam.kafka.protobuf.TestEntity.Entity;
 
@@ -13,6 +17,20 @@ public class Send extends Kafka {
         final ConsumerRecord<String, Bytes> record = consumeSingleEvent();
         final Entity entity = Entity.parseFrom(record.value().get());
         return entity.getName().equals("happy little name") && entity.getNumber() == 12;
+    }
+
+    public boolean hasReceivedEventWithHeaders() throws InvalidProtocolBufferException, UnsupportedEncodingException {
+        final ConsumerRecord<String, Bytes> record = consumeSingleEvent();
+        final Entity entity = Entity.parseFrom(record.value().get());
+        final String replyToTopic = header(record.headers(), EventHeader.REPLY_TOPIC);
+        final String correlationId = header(record.headers(), EventHeader.CORRELATION_ID);
+        return entity.getName().equals("happy little name") && entity.getNumber() == 12
+            && replyToTopic.equals("test.reply.topic") && correlationId.equals("123");
+    }
+
+    private String header(final Headers headers, final String headerName) throws UnsupportedEncodingException {
+        final byte[] bytes = headers.headers(headerName).iterator().next().value();
+        return new String(bytes, "UTF-8");
     }
 
 }

--- a/src/test/resources/specs/kafka/check/CheckAndReply.md
+++ b/src/test/resources/specs/kafka/check/CheckAndReply.md
@@ -4,8 +4,8 @@
     <e:summary/>
     <e:example name="Event must be received and then a success event must be send back">
         <e:given>        
-            <e:event-check>
-                <expected topicName="test.consume.topic">
+            <e:event-check topicName="test.consume.topic">
+                <expected>
                     <protobuf class="com.adven.concordion.extensions.exam.kafka.protobuf.TestEntity$Entity">
                     {
                         "name": "Make something good",

--- a/src/test/resources/specs/kafka/send/Send.md
+++ b/src/test/resources/specs/kafka/send/Send.md
@@ -2,15 +2,38 @@
 
 <div print="true">
     <e:summary/>
-    <e:example name="Kafka test send">
+    <e:example name="Send message to kafka">
         <e:when>
             <e:event-send topicName="test.produce.topic" key="messageKey">
-                <protobuf class="com.adven.concordion.extensions.exam.kafka.protobuf.TestEntity$Entity">
-                {
-                    "name": "happy little name",
-                    "number": 12
-                }
-                </protobuf>
+                <value>
+                    <protobuf class="com.adven.concordion.extensions.exam.kafka.protobuf.TestEntity$Entity">
+                    {
+                        "name": "happy little name",
+                        "number": 12
+                    }
+                    </protobuf>
+                </value>
+            </e:event-send>
+        </e:when>
+        <e:then>
+            <span c:assertTrue="hasReceivedEvent()">Successfuly received event</span>
+        </e:then>
+    </e:example>
+    <e:example name="Send message with headers to kafka">
+        <e:when>
+            <e:event-send topicName="test.produce.topic" key="messageKey">
+                <headers>
+                    <replyToTopic>test.reply.topic</replyToTopic>
+                    <correlationId>123</correlationId>
+                </headers>
+                <value>
+                    <protobuf class="com.adven.concordion.extensions.exam.kafka.protobuf.TestEntity$Entity">
+                    {
+                        "name": "happy little name",
+                        "number": 12
+                    }
+                    </protobuf>
+                </value>
             </e:event-send>
         </e:when>
         <e:then>

--- a/src/test/resources/specs/kafka/send/Send.md
+++ b/src/test/resources/specs/kafka/send/Send.md
@@ -37,7 +37,7 @@
             </e:event-send>
         </e:when>
         <e:then>
-            <span c:assertTrue="hasReceivedEvent()">Successfuly received event</span>
+            <span c:assertTrue="hasReceivedEventWithHeaders()">Successfuly received event with correct headers</span>
         </e:then>
     </e:example>
 </div>    


### PR DESCRIPTION
* added support of kafka message headers (`correlationId` and `replyToTopic` for now)
* if headers were specified in `EventSendCommand`, they will be used in the record, which will be send
* moved parsing of kafka/protobuf/header html blocks to separate entities (see `HtmlBlockParser` interface) which are reused in both `EventSendCommand` and `EventCheckReplyCommand` (also will be reused in key-value module in future)