### PR TITLE
changed proto comparison

### DIFF
--- a/src/main/java/com/adven/concordion/extensions/exam/entities/ProtoEntity.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/entities/ProtoEntity.java
@@ -1,6 +1,5 @@
 package com.adven.concordion.extensions.exam.entities;
 
-import com.adven.concordion.extensions.exam.utils.protobuf.ProtoToJson;
 import com.adven.concordion.extensions.exam.utils.protobuf.ProtoUtils;
 import com.google.common.base.Optional;
 import com.google.protobuf.Message;
@@ -46,9 +45,9 @@ public final class ProtoEntity extends AbstractEntity<Message> {
 
     @Override
     public boolean isEqualTo(final byte[] bytes) {
-        final Optional<String> valueToCheck = ProtoUtils.fromBytesToJson(Bytes.wrap(bytes), className, descriptors);
-        if (valueToCheck.isPresent()) {
-            return isEqualTo(valueToCheck.get());
+        final Optional<Message> convert = ProtoUtils.fromBytesToProto(Bytes.wrap(bytes), className, descriptors);
+        if (convert.isPresent()) {
+            return isEqualTo(convert.get());
         }
         return false;
     }
@@ -57,15 +56,15 @@ public final class ProtoEntity extends AbstractEntity<Message> {
     public boolean isEqualTo(final Object object) {
         Message cast = null;
         try {
-            cast = Message.class.cast(object);
+            cast = (Message) object;
         } catch (ClassCastException e) {
             log.error("Failed to cast value={} to string", object);
         }
         if (cast == null) {
             return false;
         } else {
-            val convert = new ProtoToJson<>().convert(cast);
-            return convert.isPresent() && isEqualTo(convert.get());
+            final Optional<Message> convert = ProtoUtils.fromJsonToProto(getValue(), className, descriptors);
+            return convert.isPresent() && cast.equals(convert.get());
         }
     }
 

--- a/src/main/java/com/adven/concordion/extensions/exam/utils/protobuf/ProtoUtils.java
+++ b/src/main/java/com/adven/concordion/extensions/exam/utils/protobuf/ProtoUtils.java
@@ -39,6 +39,23 @@ public final class ProtoUtils {
         return fromBytesToJson(bytes, className, descriptors.toArray(new Descriptor[]{}));
     }
 
+    public static Optional<Message> fromBytesToProto(final Bytes bytes, final String className,
+                                                     final List<String> descriptorClasses) {
+        final List<Descriptor> descriptors = descriptorInstances(descriptorClasses);
+        final Optional<Class<Message>> clazz = safeForName(className);
+        if (clazz.isPresent()) {
+            final BytesToProto<Message> converter = new BytesToProto<>(clazz.get());
+            converter.addAllDescriptors(descriptors);
+            return converter.convert(bytes);
+        }
+        return Optional.absent();
+    }
+
+    public static Optional<Message> fromBytesToProto(final Bytes bytes, final String className,
+                                                     final String... descriptors) {
+        return fromBytesToProto(bytes, className, Arrays.asList(descriptors));
+    }
+
     public static Optional<Message> fromJsonToProto(final String message, final String className,
                                                     final Descriptor... descriptors) {
         Optional<Class<Message>> clazz = safeForName(className);

--- a/src/test/resources/specs/db/kv/check/KVCheckWithProtobuf.md
+++ b/src/test/resources/specs/db/kv/check/KVCheckWithProtobuf.md
@@ -15,7 +15,7 @@
             <e:db-kv-check cache="test.cache">
                 <key>shortKey</key>
                 <value>
-                    <protobuf>
+                    <protobuf class="com.adven.concordion.extensions.exam.utils.protobuf.TestEntity$Entity">
                     {
                         "name": "living in db",
                         "number": 48
@@ -30,7 +30,7 @@
             <e:db-kv-check cache="test.cache">
                 <key>shortKey</key>
                 <value>
-                    <protobuf>
+                    <protobuf class="com.adven.concordion.extensions.exam.utils.protobuf.TestEntity$Entity">
                     {
                         "name": "not living in db",
                         "number": 48
@@ -45,7 +45,7 @@
             <e:db-kv-check cache="test.cache">
                 <key>another</key>
                 <value>
-                    <protobuf>
+                    <protobuf class="com.adven.concordion.extensions.exam.utils.protobuf.TestEntity$Entity">
                     {
                         "name": "not living in db",
                         "number": 48


### PR DESCRIPTION
Was: actual object was converted to string and compared with expected string
Become: actual object is converted to proto entity and expected string is also converted to proto entity